### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-load-testing.yml
+++ b/.github/workflows/contoso-traders-load-testing.yml
@@ -3,6 +3,10 @@ name: contoso-traders-load-testing
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  secrets: read
+
 env:
   KV_NAME: contosotraderskv
   LOAD_TEST_SERVICE_NAME: contoso-traders-loadtest


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-168/aiw-devops-with-github-lab-files/security/code-scanning/1](https://github.com/github-cloudlabsuser-168/aiw-devops-with-github-lab-files/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are appropriate:
- `contents: read` to allow the workflow to read repository contents.
- `secrets: read` to access the secrets required for Azure login and other operations.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient since both jobs require similar permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
